### PR TITLE
Fix parse_data_type to supprot tuple type

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -596,6 +596,15 @@ impl<'a> Parser<'a> {
             Ok(CqlType::Collection(CollectionType::Set(Box::new(
                 inner_type,
             ))))
+        } else if self.expect(TokenType::Keyword(Keyword::Tuple)).is_ok() {
+            self.expect(TokenType::Lt)?;
+            let mut inner_types = Vec::new();
+            inner_types.push(self.parse_data_type()?);
+            while self.expect(TokenType::Comma).is_ok() {
+                inner_types.push(self.parse_data_type()?);
+            }
+            self.expect(TokenType::Gt)?;
+            Ok(CqlType::Tuple(inner_types))
         } else {
             Err(ParseError::new())
         }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -30,7 +30,12 @@ fn test_create() {
             )]),
         ),
         (
-            "CREATE TABLE ks.test (key int, values set<text>, PRIMARY KEY ((key))) WITH prop = 2",
+            "CREATE TABLE ks.test (
+                key int,
+                values set<text>,
+                col1 frozen<tuple<text, int>>,
+                PRIMARY KEY ((key))
+            ) WITH prop = 2",
             Ok(vec![CqlStatement::CreateTable(CreateTableStatement {
                 name: QualifiedName::new(Some(String::from("ks")), String::from("test")),
                 if_not_exists: false,
@@ -41,6 +46,13 @@ fn test_create() {
                         CqlType::Collection(CollectionType::Set(Box::new(CqlType::Native(
                             NativeDataType::Text,
                         )))),
+                    ),
+                    (
+                        String::from("col1"),
+                        CqlType::Frozen(Box::new(CqlType::Tuple(vec![
+                            CqlType::Native(NativeDataType::Text),
+                            CqlType::Native(NativeDataType::Int),
+                        ]))),
                     ),
                 ],
                 static_columns: vec![],


### PR DESCRIPTION
`parse_data_type` does not support parsing `tuple<type1, type2>` definition.

Fix to add support for tuple type.